### PR TITLE
Add `files` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "author": "Eli Skeggs, C. Scott Ananian, Kevin Kwok",
   "description": "a pure-JavaScript Node.JS module for random-access decoding bzip2 data",
   "main": "./seek-bzip/index.js",
+  "files": [
+    "bin",
+    "LICENSE",
+    "seek-bzip"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/cscott/seek-bzip.git"


### PR DESCRIPTION
Because the `test` directory includes more than 2 MB files and it doesn't need to be included in the npm package. (Close #3)

https://www.npmjs.org/doc/files/package.json.html#files
