### PR TITLE
Allow newer commander versions & cover more Node.js versions on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 sudo: false
 node_js:
+  - "stable"
+  - "8"
+  - "6"
+  - "4"
   - "0.12"
   - "0.10"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "test"
   },
   "dependencies": {
-    "commander": "~2.8.1"
+    "commander": "^2.8.1"
   },
   "devDependencies": {
     "fibers": "~1.0.6",


### PR DESCRIPTION
This would allow better deduplication as commander is a very common dependency.